### PR TITLE
Two fixes in the setup.sh file

### DIFF
--- a/src/setup.sh
+++ b/src/setup.sh
@@ -7,6 +7,10 @@ else
     PRE_COMMIT_EXISTS=0
 fi
 
+if [ ! -d .git/hooks ]; then
+  mkdir -p .git/hooks
+fi
+
 cp ./vendor/wickedreports/phpcs-git-pre-commit/src/pre-commit .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 

--- a/src/setup.sh
+++ b/src/setup.sh
@@ -7,7 +7,7 @@ else
     PRE_COMMIT_EXISTS=0
 fi
 
-cp ./vendor/smgladkovskiy/phpcs-git-pre-commit/src/pre-commit .git/hooks/pre-commit
+cp ./vendor/wickedreports/phpcs-git-pre-commit/src/pre-commit .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 
 if [ "$PRE_COMMIT_EXISTS" = 0 ];


### PR DESCRIPTION
1. Fix the path to the pre-commit script in setup.sh
1. Create the hooks dir if it doesn’t exists 